### PR TITLE
Update compose package to the latest version(1.13.0).

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: docker
-version: 17.03.1-ce-1
+version: 17.03.1-ce-2
 summary: Docker Linux container runtime
 description: Docker complements kernel namespacing with a high-level API which operates at the process level. It runs unix processes with strong guarantees of isolation and repeatability across servers.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -211,7 +211,7 @@ parts:
   compose:
     plugin: python
     python-version: python2
-    source: https://github.com/docker/compose/archive/1.12.0.tar.gz
+    source: https://github.com/docker/compose/archive/1.13.0.tar.gz
     source-type: tar
 
 # vim:set et ts=2 sw=2:


### PR DESCRIPTION
Piping a docker-compose.yaml from stdin to docker.compose doesn't work in 1.12.0 which is the one we're using for docker_17.03.1-ce-1 snapping.
It's officially fixed in 1.13.0.
We need to include this in the next around snap release once the upcoming quarterly release(17.06-ce) is out.
Fixed #9 