### PR TITLE
Point to the launchpad repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains the source for the `docker` snap package.  The package 
 
 > *NOTE:* The Docker Snap is no longer maintained by Docker, Inc.  The last
 > release version was 17.06.2 and will not be updated.  The future of the Docker
-> Snap is unclear, but it won't be developed here going forward. The source at https://code.launchpad.net/~docker/+git/snapma > may be updated. Questions for that repository may be asked at https://forum.snapcraft.io/.
+> Snap is unclear, but it won't be developed here going forward. The source at https://code.launchpad.net/~docker/+git/snap 
+> may be updated. Questions for that repository may be asked at https://forum.snapcraft.io/.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This repository contains the source for the `docker` snap package.  The package 
 
 > *NOTE:* The Docker Snap is no longer maintained by Docker, Inc.  The last
 > release version was 17.06.2 and will not be updated.  The future of the Docker
-> Snap is unclear, but it won't be developed here going forward.  This
-> repository will redirect to its new home if one will exist.
+> Snap is unclear, but it won't be developed here going forward. The source at https://code.launchpad.net/~docker/+git/snapma > may be updated. Questions for that repository may be asked at https://forum.snapcraft.io/.
 
 ## Installation
 


### PR DESCRIPTION
Feel free to reword - reflecting the statement at https://forum.snapcraft.io/t/the-future-of-the-docker-snap/7218/12

Can we formally mark this repository as archived? Or maybe you can redirect it to launchpad?

I suppose it doesn't make sense to give the launchpad folks ownership over a repo in the docker group.